### PR TITLE
Fix multimonitor mouse movement for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,13 +28,24 @@ else()
     set(UIOHOOK_SOURCE_DIR "x11")
 endif()
 
-add_library(uiohook
-    "src/logger.c"
-    "src/${UIOHOOK_SOURCE_DIR}/input_helper.c"
-    "src/${UIOHOOK_SOURCE_DIR}/input_hook.c"
-    "src/${UIOHOOK_SOURCE_DIR}/post_event.c"
-    "src/${UIOHOOK_SOURCE_DIR}/system_properties.c"
-)
+if (WIN32 OR WIN64)
+    add_library(uiohook
+        "src/logger.c"
+        "src/${UIOHOOK_SOURCE_DIR}/input_helper.c"
+        "src/${UIOHOOK_SOURCE_DIR}/input_hook.c"
+        "src/${UIOHOOK_SOURCE_DIR}/post_event.c"
+        "src/${UIOHOOK_SOURCE_DIR}/system_properties.c"
+        "src/${UIOHOOK_SOURCE_DIR}/monitor_helper.c"
+    )
+else()
+    add_library(uiohook
+        "src/logger.c"
+        "src/${UIOHOOK_SOURCE_DIR}/input_helper.c"
+        "src/${UIOHOOK_SOURCE_DIR}/input_hook.c"
+        "src/${UIOHOOK_SOURCE_DIR}/post_event.c"
+        "src/${UIOHOOK_SOURCE_DIR}/system_properties.c"
+    )
+endif ()
 
 set_target_properties(uiohook PROPERTIES
     C_STANDARD 99

--- a/include/uiohook.h
+++ b/include/uiohook.h
@@ -41,6 +41,7 @@
 // Windows specific errors.
 #define UIOHOOK_ERROR_SET_WINDOWS_HOOK_EX        0x30
 #define UIOHOOK_ERROR_GET_MODULE_HANDLE          0x31
+#define UIOHOOK_ERROR_CREATE_INVISIBLE_WINDOW    0x32
 
 // Darwin specific errors.
 #define UIOHOOK_ERROR_AXAPI_DISABLED             0x40

--- a/src/windows/input_hook.c
+++ b/src/windows/input_hook.c
@@ -755,7 +755,7 @@ static int create_invisible_window()
     wcex.hCursor = NULL;
     wcex.hbrBackground = NULL;
     wcex.lpszMenuName = NULL;
-    wcex.lpszClassName = "Empty";
+    wcex.lpszClassName = "libuiohook";
     wcex.hIconSm = NULL;
 
     if (!RegisterClassEx(&wcex)) {
@@ -764,8 +764,8 @@ static int create_invisible_window()
 
     invisible_win_hwnd = CreateWindowEx(
             WS_EX_NOACTIVATE,
-            "Empty",
-            "Empty",
+            "libuiohook",
+            "Hidden Window to Monitor Display Change Events",
             WS_DISABLED,
             0,
             0,

--- a/src/windows/monitor_helper.c
+++ b/src/windows/monitor_helper.c
@@ -1,0 +1,37 @@
+#include "monitor_helper.h"
+
+static LONG left = 0;
+static LONG top = 0;
+
+static BOOL CALLBACK enum_monitor_proc(HMONITOR h_monitor, HDC hdc, LPRECT lp_rect, LPARAM dwData) {
+    MONITORINFO MonitorInfo = {0};
+    MonitorInfo.cbSize = sizeof(MonitorInfo);
+    if (GetMonitorInfo(h_monitor, &MonitorInfo)) {
+        if (MonitorInfo.rcMonitor.left < left) {
+            left = MonitorInfo.rcMonitor.left;
+        }
+        if (MonitorInfo.rcMonitor.top < top) {
+            top = MonitorInfo.rcMonitor.top;
+        }
+    }
+    return TRUE;
+}
+
+void enumerate_displays()
+{
+    // Reset coordinates because if a negative monitor moves to positive space,
+    // it will still look like there is some monitor in negative space.
+    left = 0;
+    top = 0;
+
+    EnumDisplayMonitors(NULL, NULL, enum_monitor_proc, 0);
+}
+
+LARGESTNEGATIVECOORDINATES get_largest_negative_coordinates()
+{
+    LARGESTNEGATIVECOORDINATES lnc = {
+            .left = left,
+            .top = top
+    };
+    return lnc;
+}

--- a/src/windows/monitor_helper.h
+++ b/src/windows/monitor_helper.h
@@ -1,0 +1,10 @@
+#include <Windows.h>
+
+typedef struct {
+    LONG left;
+    LONG top;
+} LARGESTNEGATIVECOORDINATES;
+
+extern void enumerate_displays();
+
+extern LARGESTNEGATIVECOORDINATES get_largest_negative_coordinates();

--- a/src/windows/post_event.c
+++ b/src/windows/post_event.c
@@ -64,11 +64,58 @@ static const uint16_t extend_key_table[10] = {
     VK_DELETE
 };
 
+typedef struct {
+    LONG x;
+    LONG y;
+} normalized_coordinate;
 
-static LONG convert_to_relative_position(int coordinate, int screen_size) {
-    // See https://stackoverflow.com/a/4555214 and its comments
-	int offset = (coordinate > 0 ? 1 : -1); // Negative coordinates appear when using multiple monitors
-	return ((coordinate * MAX_WINDOWS_COORD_VALUE) / screen_size) + offset;
+typedef struct  {
+    LONG left;
+    LONG top;
+} largest_negative_coordinates;
+
+static LONG get_absolute_coordinate(LONG coordinate, int screen_size) {
+    return MulDiv((int) coordinate, MAX_WINDOWS_COORD_VALUE, screen_size);
+}
+
+static normalized_coordinate normalize_coordinates(LONG x, LONG y, int screen_width, int screen_height, largest_negative_coordinates lnc) {
+    x += abs(lnc.left);
+    y += abs(lnc.top);
+
+    // Prevent clicking 0 coordinates to prevent monitor flicker
+    if (x == 0)
+    {
+        x++;
+    }
+    if (y == 0)
+    {
+        y++;
+    }
+
+    normalized_coordinate nc = {
+            .x = get_absolute_coordinate(x, screen_width),
+            .y = get_absolute_coordinate(y, screen_height)
+    };
+
+    return nc;
+}
+
+static BOOL CALLBACK get_largest_negative_coordinates_monitor_proc(HMONITOR h_monitor, HDC hdc, LPRECT lp_rect, LPARAM dwData) {
+    MONITORINFO MonitorInfo = {0};
+    MonitorInfo.cbSize = sizeof(MonitorInfo);
+    largest_negative_coordinates* lnc = (largest_negative_coordinates*)dwData;
+    if (GetMonitorInfo(h_monitor, &MonitorInfo))
+    {
+        if (MonitorInfo.rcMonitor.left < lnc->left)
+        {
+            lnc->left = MonitorInfo.rcMonitor.left;
+        }
+        if (MonitorInfo.rcMonitor.top < lnc->top)
+        {
+            lnc->top = MonitorInfo.rcMonitor.top;
+        }
+    }
+    return TRUE;
 }
 
 static int map_keyboard_event(uiohook_event * const event, INPUT * const input) {
@@ -111,17 +158,24 @@ static int map_keyboard_event(uiohook_event * const event, INPUT * const input) 
 }
 
 static int map_mouse_event(uiohook_event * const event, INPUT * const input) {
-    // FIXME implement multiple monitor support
-    uint16_t screen_width  = GetSystemMetrics(SM_CXSCREEN);
-    uint16_t screen_height = GetSystemMetrics(SM_CYSCREEN);
+    uint16_t screen_width  = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+    uint16_t screen_height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 
     input->type = INPUT_MOUSE;
     input->mi.mouseData = 0;
     input->mi.dwExtraInfo = 0;
     input->mi.time = 0; // GetSystemTime();
 
-    input->mi.dx = convert_to_relative_position(event->data.mouse.x, screen_width);
-    input->mi.dy = convert_to_relative_position(event->data.mouse.y, screen_height);
+    largest_negative_coordinates lnc = {
+            .left = 0,
+            .top = 0
+    };
+    EnumDisplayMonitors(NULL, NULL, get_largest_negative_coordinates_monitor_proc, (LPARAM) &lnc);
+
+    normalized_coordinate nc = normalize_coordinates(event->data.mouse.x, event->data.mouse.y, screen_width, screen_height, lnc);
+
+    input->mi.dx = nc.x;
+    input->mi.dy = nc.y;
 
     switch (event->type) {
         case EVENT_MOUSE_PRESSED:
@@ -130,13 +184,13 @@ static int map_mouse_event(uiohook_event * const event, INPUT * const input) {
                         __FUNCTION__, __LINE__);
                 return UIOHOOK_FAILURE;
             } else if (event->data.mouse.button == MOUSE_BUTTON1) {
-                input->mi.dwFlags = MOUSEEVENTF_LEFTDOWN;
+                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_LEFTDOWN;
             } else if (event->data.mouse.button == MOUSE_BUTTON2) {
-                input->mi.dwFlags = MOUSEEVENTF_RIGHTDOWN;
+                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_RIGHTDOWN;
             } else if (event->data.mouse.button == MOUSE_BUTTON3) {
-                input->mi.dwFlags = MOUSEEVENTF_MIDDLEDOWN;
+                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_MIDDLEDOWN;
             } else {
-                input->mi.dwFlags = MOUSEEVENTF_XDOWN;
+                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_XDOWN;
                 if (event->data.mouse.button == MOUSE_BUTTON4) {
                     input->mi.mouseData = XBUTTON1;
                 } else if (event->data.mouse.button == MOUSE_BUTTON5) {
@@ -159,13 +213,13 @@ static int map_mouse_event(uiohook_event * const event, INPUT * const input) {
                         __FUNCTION__, __LINE__);
                 return UIOHOOK_FAILURE;
             } else if (event->data.mouse.button == MOUSE_BUTTON1) {
-                input->mi.dwFlags = MOUSEEVENTF_LEFTUP;
+                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_LEFTUP;
             } else if (event->data.mouse.button == MOUSE_BUTTON2) {
-                input->mi.dwFlags = MOUSEEVENTF_RIGHTUP;
+                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_RIGHTUP;
             } else if (event->data.mouse.button == MOUSE_BUTTON3) {
-                input->mi.dwFlags = MOUSEEVENTF_MIDDLEUP;
+                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_MIDDLEUP;
             } else {
-                input->mi.dwFlags = MOUSEEVENTF_XUP;
+                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_XUP;
                 if (event->data.mouse.button == MOUSE_BUTTON4) {
                     input->mi.mouseData = XBUTTON1;
                 } else if (event->data.mouse.button == MOUSE_BUTTON5) {

--- a/src/windows/post_event.c
+++ b/src/windows/post_event.c
@@ -158,13 +158,13 @@ static int map_mouse_event(uiohook_event * const event, INPUT * const input) {
                         __FUNCTION__, __LINE__);
                 return UIOHOOK_FAILURE;
             } else if (event->data.mouse.button == MOUSE_BUTTON1) {
-                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_LEFTDOWN;
+                input->mi.dwFlags = MOUSEEVENTF_LEFTDOWN;
             } else if (event->data.mouse.button == MOUSE_BUTTON2) {
-                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_RIGHTDOWN;
+                input->mi.dwFlags = MOUSEEVENTF_RIGHTDOWN;
             } else if (event->data.mouse.button == MOUSE_BUTTON3) {
-                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_MIDDLEDOWN;
+                input->mi.dwFlags = MOUSEEVENTF_MIDDLEDOWN;
             } else {
-                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_XDOWN;
+                input->mi.dwFlags = MOUSEEVENTF_XDOWN;
                 if (event->data.mouse.button == MOUSE_BUTTON4) {
                     input->mi.mouseData = XBUTTON1;
                 } else if (event->data.mouse.button == MOUSE_BUTTON5) {
@@ -187,13 +187,13 @@ static int map_mouse_event(uiohook_event * const event, INPUT * const input) {
                         __FUNCTION__, __LINE__);
                 return UIOHOOK_FAILURE;
             } else if (event->data.mouse.button == MOUSE_BUTTON1) {
-                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_LEFTUP;
+                input->mi.dwFlags = MOUSEEVENTF_LEFTUP;
             } else if (event->data.mouse.button == MOUSE_BUTTON2) {
-                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_RIGHTUP;
+                input->mi.dwFlags = MOUSEEVENTF_RIGHTUP;
             } else if (event->data.mouse.button == MOUSE_BUTTON3) {
-                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_MIDDLEUP;
+                input->mi.dwFlags = MOUSEEVENTF_MIDDLEUP;
             } else {
-                input->mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_XUP;
+                input->mi.dwFlags = MOUSEEVENTF_XUP;
                 if (event->data.mouse.button == MOUSE_BUTTON4) {
                     input->mi.mouseData = XBUTTON1;
                 } else if (event->data.mouse.button == MOUSE_BUTTON5) {

--- a/src/windows/post_event.c
+++ b/src/windows/post_event.c
@@ -22,6 +22,7 @@
 
 #include "input_helper.h"
 #include "logger.h"
+#include "monitor_helper.h"
 
 // Some buggy versions of MinGW and MSys do not include these constants in winuser.h.
 #ifndef MAPVK_VK_TO_VSC
@@ -69,16 +70,11 @@ typedef struct {
     LONG y;
 } normalized_coordinate;
 
-typedef struct  {
-    LONG left;
-    LONG top;
-} largest_negative_coordinates;
-
 static LONG get_absolute_coordinate(LONG coordinate, int screen_size) {
     return MulDiv((int) coordinate, MAX_WINDOWS_COORD_VALUE, screen_size);
 }
 
-static normalized_coordinate normalize_coordinates(LONG x, LONG y, int screen_width, int screen_height, largest_negative_coordinates lnc) {
+static normalized_coordinate normalize_coordinates(LONG x, LONG y, int screen_width, int screen_height, LARGESTNEGATIVECOORDINATES lnc) {
     x += abs(lnc.left);
     y += abs(lnc.top);
 
@@ -98,24 +94,6 @@ static normalized_coordinate normalize_coordinates(LONG x, LONG y, int screen_wi
     };
 
     return nc;
-}
-
-static BOOL CALLBACK get_largest_negative_coordinates_monitor_proc(HMONITOR h_monitor, HDC hdc, LPRECT lp_rect, LPARAM dwData) {
-    MONITORINFO MonitorInfo = {0};
-    MonitorInfo.cbSize = sizeof(MonitorInfo);
-    largest_negative_coordinates* lnc = (largest_negative_coordinates*)dwData;
-    if (GetMonitorInfo(h_monitor, &MonitorInfo))
-    {
-        if (MonitorInfo.rcMonitor.left < lnc->left)
-        {
-            lnc->left = MonitorInfo.rcMonitor.left;
-        }
-        if (MonitorInfo.rcMonitor.top < lnc->top)
-        {
-            lnc->top = MonitorInfo.rcMonitor.top;
-        }
-    }
-    return TRUE;
 }
 
 static int map_keyboard_event(uiohook_event * const event, INPUT * const input) {
@@ -166,11 +144,7 @@ static int map_mouse_event(uiohook_event * const event, INPUT * const input) {
     input->mi.dwExtraInfo = 0;
     input->mi.time = 0; // GetSystemTime();
 
-    largest_negative_coordinates lnc = {
-            .left = 0,
-            .top = 0
-    };
-    EnumDisplayMonitors(NULL, NULL, get_largest_negative_coordinates_monitor_proc, (LPARAM) &lnc);
+    LARGESTNEGATIVECOORDINATES lnc = get_largest_negative_coordinates();
 
     normalized_coordinate nc = normalize_coordinates(event->data.mouse.x, event->data.mouse.y, screen_width, screen_height, lnc);
 


### PR DESCRIPTION
Hello again! This PR fixes libuiohook's issue with multi-monitor mouse input and movement for Windows.

Very quickly, this is done by converting the low-level mouse hook coordinates that libuiohook returns to be relative to the virtual desktop. I wrote some notes and examples here if you want to take a look: https://i.imgur.com/z3vKjtm.png

This is a video showing Sharphook without this change at first, and then Sharphook with my change. An app.manifest with per monitor dpi awareness is still required to work with DPI's that are not 100%.
https://youtu.be/TxGJ2PKHfNI

It's hard to see because I'm recording three monitors, but I created a C# program to press the right mouse button at the cursor's current position when I release the middle mouse button. At first, trying this causes the mouse to jump across the monitors. After updating the Sharphook package, it successfully clicks at the proper position.

This is the sample program:

```
using SharpHook;
using SharpHook.Native;

short x = 0;
short y = 0;

var lockObj = new object();

var hook = new TaskPoolGlobalHook();
var sim = new EventSimulator();

hook.MouseReleased += OnMouseReleased;
hook.MouseMoved += OnMouseMoved;

await hook.RunAsync();

void OnMouseReleased(object? sender, MouseHookEventArgs e)
{
    if (e.Data.Button != MouseButton.Button3)
    {
        return;
    }

    lock (lockObj)
    {
        sim.SimulateMousePress(x, y, MouseButton.Button2);
        sim.SimulateMouseRelease(x, y, MouseButton.Button2);
    }
}

void OnMouseMoved(object? sender, MouseHookEventArgs e)
{
    lock (lockObj)
    {
        x = e.Data.X;
        y = e.Data.Y;
    }
}
```

I'd like to point out on line 173 that I call EnumDisplayMonitors. This is called whenever you send a mouse input/move which is pretty slow, but working and slow is better than not working at all :). The positive to this is that it can handle monitor resizes and moves without restarting the application.
https://github.com/FaithBeam/libuiohook/blob/30a86b05cb6ee1eafc6f306555600d674a3fe0d7/src/windows/post_event.c#L173

A potential performance improvement could be made by creating an empty, invisible window that listens for the WM_DISPLAYCHANGE event and perform an EnumDisplayMonitors then.